### PR TITLE
添加了获取token串的方法，在示例中添加了常用的使用方式。

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,12 @@ $token = JWTAuth::builder(['uid' => 1]);//参数为用户认证的信息，请�
 JWTAuth::auth();//token验证
 
 JWTAuth::refresh();//刷新token，会将旧token加入黑名单
-        
+
+$tokenStr = JWTAuth::token()->get(); //可以获取请求中的完整token字符串
+
+$payload = JWTAuth::auth(); //可验证token, 并获取token中的payload部分
+$uid = $payload['uid']->getValue(); //可以继而获取payload里自定义的字段，比如uid
+
 ```
 token刷新说明：
 

--- a/src/JWTAuth.php
+++ b/src/JWTAuth.php
@@ -31,6 +31,16 @@ class JWTAuth extends JWT
     }
 
     /**
+     * 获取Token
+     *
+     * @return mixed
+     */
+    public function token()
+    {
+        return $this->getToken();
+    }
+
+    /**
      * 添加Token至黑名单
      *
      * @param $token


### PR DESCRIPTION
获取token的场景很多，还是暴露出来方便一些。

针对https://github.com/QThans/jwt-auth/issues/13 ， https://github.com/QThans/jwt-auth/issues/16 提到的payload如何使用，添加了说明